### PR TITLE
Update flatstore-users

### DIFF
--- a/flatstore-users
+++ b/flatstore-users
@@ -1,5 +1,5 @@
 root
 gdm
 freerad
-radius
+radiusd
 trustrouter


### PR DESCRIPTION
The FreeRADIUS user on Fedora systems is radiusd, not radius.
